### PR TITLE
修复pydantic2的extra参数

### DIFF
--- a/nonebot_plugin_batarot/config.py
+++ b/nonebot_plugin_batarot/config.py
@@ -11,6 +11,6 @@ class Config(BaseSettings):
 
     class Config:
         env_file = ".env.prod" 
-        # extra = "ignored"
+        # extra = "ignore"
 
 config = Config()


### PR DESCRIPTION
修复pydantic2的extra参数, 应为"ignore"