### PR TITLE
fix(config): 兼容 pydantic v1 和 v2 的 BaseSettings 导入

### DIFF
--- a/nonebot_plugin_batarot/config.py
+++ b/nonebot_plugin_batarot/config.py
@@ -1,4 +1,7 @@
-from pydantic import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:
+    from pydantic import BaseSettings
 #
 # 如果你使用 pydantic2 ：
 # 1. 安装pydantic_settings包


### PR DESCRIPTION
添加 try-except 语句来处理不同版本的 pydantic 导入，确保插件在 pydantic v1 和 v2 下都能正常运行